### PR TITLE
feat: refresh UI with playful theme

### DIFF
--- a/Frontend/src/components/ElephantMascot.jsx
+++ b/Frontend/src/components/ElephantMascot.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import "../styles/ElephantMascot.css";
+
+const ElephantMascot = () => {
+  return (
+    <div className="elephant-mascot sticker" aria-hidden="true">
+      <span role="img" aria-label="Elephant mascot">🐘</span>
+    </div>
+  );
+};
+
+export default ElephantMascot;

--- a/Frontend/src/components/Layout.jsx
+++ b/Frontend/src/components/Layout.jsx
@@ -2,6 +2,7 @@ import { useLocation } from "react-router-dom";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
 import ChatbotWidget from "./ChatbotWidget";
+import ElephantMascot from "./ElephantMascot";
 import "../styles/Layout.css";
 
 const Layout = ({ children }) => {
@@ -14,6 +15,7 @@ const Layout = ({ children }) => {
       <main className="layout-main">{children}</main>
       <ChatbotWidget />
       <Footer />
+      <ElephantMascot />
     </div>
   );
 };

--- a/Frontend/src/styles/ElephantMascot.css
+++ b/Frontend/src/styles/ElephantMascot.css
@@ -1,0 +1,9 @@
+.elephant-mascot {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  font-size: 5rem;
+  transform: perspective(500px) rotateY(-15deg);
+  filter: drop-shadow(0 8px 6px rgba(0, 0, 0, 0.2));
+  z-index: 1000;
+}

--- a/Frontend/src/styles/Navbar.css
+++ b/Frontend/src/styles/Navbar.css
@@ -34,7 +34,7 @@
 .logo {
   font-size: 1.8rem;
   font-weight: 700;
-  background: linear-gradient(135deg, #f5362e, #0484d6, #072b80);
+  background: linear-gradient(135deg, var(--secondary-color), var(--primary-color));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -72,8 +72,8 @@
 
 .navMenu a:hover,
 .navMenu a.active {
-  color: var(--primary-color);
-  border-bottom-color: var(--primary-color);
+  color: var(--secondary-color);
+  border-bottom-color: var(--secondary-color);
 }
 
 .navControls {
@@ -86,8 +86,8 @@
 }
 
 .loginButton {
-  background-color: #073b80; /* Changed from var(--primary-color) */
-  color: #ffffff !important; /* Set login text color to white */
+  background-color: var(--secondary-color);
+  color: var(--background-color) !important;
   padding: 8px 20px;
   border-radius: 20px;
   font-weight: 600;
@@ -95,9 +95,9 @@
 }
 
 .loginButton:hover {
-  background-color: #f5362e; /* Changed from var(--accent-color) */
-  color: #ffffff !important;
-  transform: scale(1.05); /* This could cause layout shift */
+  background-color: var(--primary-color);
+  color: var(--background-color) !important;
+  transform: scale(1.05);
 }
 
 .searchButton {
@@ -112,8 +112,8 @@
   transition: color 0.2s, transform 0.2s;
 }
 .searchButton:hover {
-  color: #073b80;
-  transform: scale(1.15); /* This could cause layout shift */
+  color: var(--secondary-color);
+  transform: scale(1.15);
 }
 
 .profileIcon {
@@ -175,8 +175,8 @@
   position: absolute;
   right: 0;
   margin-top: 0.5rem;
-  background-color: white;
-  border: 1px solid #ddd;
+  background-color: var(--surface-color);
+  border: 1px solid var(--primary-color);
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   min-width: 160px;
@@ -186,12 +186,12 @@
 .dropdownItem {
   display: block;
   padding: 10px 15px;
-  color: #333;
+  color: var(--text-primary);
   text-decoration: none;
 }
 
 .dropdownItem:hover {
-  background-color: #f5f5f5;
+  background-color: var(--accent-color);
 }
 .ai-planner-button {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/Frontend/src/styles/main.css
+++ b/Frontend/src/styles/main.css
@@ -1,31 +1,31 @@
 /* Google Fonts */
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600;700&display=swap");
 
 /* CSS Variables for Theming */
 :root {
-  --font-main: "Poppins", sans-serif;
+  --font-main: "Fredoka", sans-serif;
 
   /* Light Theme */
-  --primary-color: #0484d6;
-  --secondary-color: #002b7f;
-  --accent-color: #77ccff;
-  --background-color: #f4f8fa;
-  --surface-color: #ffffff;
-  --text-primary: #121212;
-  --text-secondary: #555555;
-  --glow-color: rgba(4, 132, 214, 0.5);
+  --primary-color: #ffd54f; /* Soft yellow */
+  --secondary-color: #ff8f00; /* Orangey accent */
+  --accent-color: #ffecb3; /* Pale highlight */
+  --background-color: #fffbe6; /* Light background */
+  --surface-color: #fff3c4; /* Card surfaces */
+  --text-primary: #4a3525;
+  --text-secondary: #7a5f45;
+  --glow-color: rgba(255, 213, 79, 0.6);
 }
 
 [data-theme="dark"] {
   /* Dark Theme */
-  --primary-color: #77ccff;
-  --secondary-color: #e0f7fa;
-  --accent-color: #0484d6;
-  --background-color: #001f3f; /* Dark Navy */
-  --surface-color: #002b5c; /* Darker Navy */
-  --text-primary: #f4f8fa;
-  --text-secondary: #b0c4de;
-  --glow-color: rgba(119, 204, 255, 0.6);
+  --primary-color: #ffecb3;
+  --secondary-color: #ffd54f;
+  --accent-color: #ff8f00;
+  --background-color: #403000;
+  --surface-color: #5c4200;
+  --text-primary: #fffbe6;
+  --text-secondary: #ffe0b2;
+  --glow-color: rgba(255, 236, 179, 0.4);
 }
 
 * {
@@ -58,6 +58,15 @@ a {
 
 a:hover {
   color: var(--accent-color);
+}
+
+.sticker {
+  background: var(--accent-color);
+  border: 4px solid #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.15);
+  padding: 0.25rem;
+  transform: rotate(-3deg);
 }
 
 .container {


### PR DESCRIPTION
## Summary
- switch global palette to warm yellows and playful fonts
- add sticker-style class and floating elephant mascot
- update navbar buttons and gradients to match new theme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 18 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1eaf2d14832f8fa51258f38ece96